### PR TITLE
Remove data len check

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -226,11 +226,12 @@ func (dec *Decoder) ReadByteSlice() (out []byte, err error) {
 		return nil, err
 	}
 
+	end := dec.pos + length
 	if len(dec.data) < dec.pos+length {
-		return nil, fmt.Errorf("byte array: varlen=%d, missing %d bytes", length, dec.pos+length-len(dec.data))
+		end = len(dec.data)
 	}
 
-	out = dec.data[dec.pos : dec.pos+length]
+	out = dec.data[dec.pos:end]
 	dec.pos += length
 	if traceEnabled {
 		zlog.Debug("decode: read byte array", zap.Stringer("hex", HexBytes(out)))

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -566,17 +566,6 @@ func TestDecoder_ByteArray(t *testing.T) {
 	assert.Equal(t, 0, d.Remaining())
 }
 
-func TestDecoder_ByteArray_MissingData(t *testing.T) {
-	buf := []byte{
-		0x0a,
-	}
-
-	d := NewBinDecoder(buf)
-
-	_, err := d.ReadByteSlice()
-	assert.EqualError(t, err, "byte array: varlen=10, missing 10 bytes")
-}
-
 func TestDecoder_Array(t *testing.T) {
 	buf := []byte{1, 2, 4}
 


### PR DESCRIPTION
Sometimes this check will break the deserialization process. borsh.js has a [workaround](https://github.com/near/borsh-js/blob/master/borsh-ts/index.ts#L480) for it, but do we really need this check?

Let me know if there's a better way to do this