### PR TITLE
Enum primitives and empty enum variants

### DIFF
--- a/borsh_test.go
+++ b/borsh_test.go
@@ -848,7 +848,7 @@ func TestBorsh_Encode(t *testing.T) {
 					},
 					ComplexEmpty: ComplexEnumEmpty{
 						Enum: 0,
-						Foo:  BorshEnumEmpty{},
+						Foo:  EmptyVariant{},
 					},
 
 					ComplexPrimitives1: ComplexEnumPrimitives{
@@ -1393,7 +1393,7 @@ type ComplexEnumPointers struct {
 
 type ComplexEnumEmpty struct {
 	Enum BorshEnum `borsh_enum:"true"`
-	Foo  BorshEnumEmpty
+	Foo  EmptyVariant
 	Bar  Bar
 }
 

--- a/borsh_test.go
+++ b/borsh_test.go
@@ -857,8 +857,8 @@ func TestBorsh_Encode(t *testing.T) {
 					},
 
 					ComplexPrimitives2: ComplexEnumPrimitives{
-						Enum: 0,
-						Foo: 20,
+						Enum: 1,
+						Bar: 11,
 					},
 
 					Complex2: ComplexEnumPointers{
@@ -961,8 +961,8 @@ func TestBorsh_Encode(t *testing.T) {
 						[]byte{20, 0, 0, 0},
 
 						// .ComplexPrimitives2
-						[]byte{0},
-						[]byte{20, 0, 0, 0},
+						[]byte{1},
+						[]byte{11, 0},
 
 						// .Complex2
 						[]byte{1},

--- a/borsh_test.go
+++ b/borsh_test.go
@@ -848,17 +848,17 @@ func TestBorsh_Encode(t *testing.T) {
 					},
 					ComplexEmpty: ComplexEnumEmpty{
 						Enum: 0,
-						Foo: BorshEnumEmpty{},
+						Foo:  BorshEnumEmpty{},
 					},
 
 					ComplexPrimitives1: ComplexEnumPrimitives{
 						Enum: 0,
-						Foo: 20,
+						Foo:  20,
 					},
 
 					ComplexPrimitives2: ComplexEnumPrimitives{
 						Enum: 1,
-						Bar: 11,
+						Bar:  11,
 					},
 
 					Complex2: ComplexEnumPointers{
@@ -1050,7 +1050,7 @@ type StructWithEnum struct {
 	ComplexPtr       *ComplexEnum
 	ComplexPtrNotSet *ComplexEnum
 
-	ComplexEmpty	  ComplexEnumEmpty
+	ComplexEmpty       ComplexEnumEmpty
 	ComplexPrimitives1 ComplexEnumPrimitives
 	ComplexPrimitives2 ComplexEnumPrimitives
 
@@ -1468,7 +1468,7 @@ func TestComplexEnum(t *testing.T) {
 	{
 		x := ComplexEnumPrimitives{
 			Enum: 1,
-			Bar: 22,
+			Bar:  22,
 		}
 		data, err := MarshalBorsh(x)
 		require.NoError(t, err)

--- a/borsh_test.go
+++ b/borsh_test.go
@@ -846,6 +846,20 @@ func TestBorsh_Encode(t *testing.T) {
 							BarB: "this is bar from pointer",
 						},
 					},
+					ComplexEmpty: ComplexEnumEmpty{
+						Enum: 0,
+						Foo: BorshEnumEmpty{},
+					},
+
+					ComplexPrimitives1: ComplexEnumPrimitives{
+						Enum: 0,
+						Foo: 20,
+					},
+
+					ComplexPrimitives2: ComplexEnumPrimitives{
+						Enum: 0,
+						Foo: 20,
+					},
 
 					Complex2: ComplexEnumPointers{
 						Enum: 1,
@@ -939,6 +953,17 @@ func TestBorsh_Encode(t *testing.T) {
 						[]byte{0, 0, 0, 0},
 						[]byte{0, 0, 0, 0},
 
+						// .ComplexEmpty
+						[]byte{0},
+
+						// .ComplexPrimitives1
+						[]byte{0},
+						[]byte{20, 0, 0, 0},
+
+						// .ComplexPrimitives2
+						[]byte{0},
+						[]byte{20, 0, 0, 0},
+
 						// .Complex2
 						[]byte{1},
 						[]byte{62, 0, 0, 0, 0, 0, 0, 0},
@@ -1024,6 +1049,10 @@ type StructWithEnum struct {
 	ComplexNotSet    ComplexEnum
 	ComplexPtr       *ComplexEnum
 	ComplexPtrNotSet *ComplexEnum
+
+	ComplexEmpty	  ComplexEnumEmpty
+	ComplexPrimitives1 ComplexEnumPrimitives
+	ComplexPrimitives2 ComplexEnumPrimitives
 
 	Complex2    ComplexEnumPointers
 	Complex2Ptr *ComplexEnumPointers
@@ -1361,6 +1390,19 @@ type ComplexEnumPointers struct {
 	Foo  *Foo
 	Bar  *Bar
 }
+
+type ComplexEnumEmpty struct {
+	Enum BorshEnum `borsh_enum:"true"`
+	Foo  BorshEnumEmpty
+	Bar  Bar
+}
+
+type ComplexEnumPrimitives struct {
+	Enum BorshEnum `borsh_enum:"true"`
+	Foo  uint32
+	Bar  int16
+}
+
 type Foo struct {
 	FooA int32
 	FooB string
@@ -1401,6 +1443,37 @@ func TestComplexEnum(t *testing.T) {
 		require.NoError(t, err)
 
 		y := new(ComplexEnumPointers)
+		err = UnmarshalBorsh(y, data)
+		require.NoError(t, err)
+
+		require.Equal(t, x, *y)
+	}
+	{
+		x := ComplexEnumEmpty{
+			Enum: 1,
+			Bar: Bar{
+				BarA: 23,
+				BarB: "baz",
+			},
+		}
+		data, err := MarshalBorsh(x)
+		require.NoError(t, err)
+
+		y := new(ComplexEnumEmpty)
+		err = UnmarshalBorsh(y, data)
+		require.NoError(t, err)
+
+		require.Equal(t, x, *y)
+	}
+	{
+		x := ComplexEnumPrimitives{
+			Enum: 1,
+			Bar: 22,
+		}
+		data, err := MarshalBorsh(x)
+		require.NoError(t, err)
+
+		y := new(ComplexEnumPrimitives)
 		err = UnmarshalBorsh(y, data)
 		require.NoError(t, err)
 

--- a/decoder_borsh.go
+++ b/decoder_borsh.go
@@ -86,10 +86,6 @@ func (dec *Decoder) decodeBorsh(rv reflect.Value, opt *option) (err error) {
 	}
 
 	rt := rv.Type()
-	if isTypeBorshEnumEmpty(rt) {
-		// Empty enum type, nothing to deserialize
-		return
-	}
 	switch rv.Kind() {
 	// case reflect.Int:
 	// 	// TODO: check if is x32 or x64
@@ -270,10 +266,6 @@ func (dec *Decoder) deserializeComplexEnum(rv reflect.Value) error {
 var borshEnumType = reflect.TypeOf(BorshEnum(0))
 
 func isTypeBorshEnum(typ reflect.Type) bool {
-	return typ.Kind() == reflect.Uint8 && typ == borshEnumType
-}
-
-func isTypeBorshEnumEmpty(typ reflect.Type) bool {
 	return typ.Kind() == reflect.Uint8 && typ == borshEnumType
 }
 

--- a/decoder_borsh.go
+++ b/decoder_borsh.go
@@ -86,6 +86,10 @@ func (dec *Decoder) decodeBorsh(rv reflect.Value, opt *option) (err error) {
 	}
 
 	rt := rv.Type()
+	if isTypeBorshEnumEmpty(rt) {
+		// Empty enum type, nothing to deserialize
+		return
+	}
 	switch rv.Kind() {
 	// case reflect.Int:
 	// 	// TODO: check if is x32 or x64
@@ -266,6 +270,10 @@ func (dec *Decoder) deserializeComplexEnum(rv reflect.Value) error {
 var borshEnumType = reflect.TypeOf(BorshEnum(0))
 
 func isTypeBorshEnum(typ reflect.Type) bool {
+	return typ.Kind() == reflect.Uint8 && typ == borshEnumType
+}
+
+func isTypeBorshEnumEmpty(typ reflect.Type) bool {
 	return typ.Kind() == reflect.Uint8 && typ == borshEnumType
 }
 

--- a/encoder_borsh.go
+++ b/encoder_borsh.go
@@ -26,6 +26,55 @@ import (
 	"go.uber.org/zap"
 )
 
+func (e *Encoder) encodePrimitive(rv reflect.Value, opt *option) (isPrimitive bool, err error) {
+	isPrimitive = true
+	switch rv.Kind() {
+	// case reflect.Int:
+	// 	err = e.WriteInt64(rv.Int(), LE)
+	// case reflect.Uint:
+	// 	err = e.WriteUint64(rv.Uint(), LE)
+	case reflect.String:
+		err = e.WriteString(rv.String())
+		break
+	case reflect.Uint8:
+		err =  e.WriteByte(byte(rv.Uint()))
+		break
+	case reflect.Int8:
+		err = e.WriteByte(byte(rv.Int()))
+		break
+	case reflect.Int16:
+		err = e.WriteInt16(int16(rv.Int()), LE)
+		break
+	case reflect.Uint16:
+		err = e.WriteUint16(uint16(rv.Uint()), LE)
+		break
+	case reflect.Int32:
+		err = e.WriteInt32(int32(rv.Int()), LE)
+		break
+	case reflect.Uint32:
+		err = e.WriteUint32(uint32(rv.Uint()), LE)
+		break
+	case reflect.Uint64:
+		err = e.WriteUint64(rv.Uint(), LE)
+		break
+	case reflect.Int64:
+		err = e.WriteInt64(rv.Int(), LE)
+		break
+	case reflect.Float32:
+		err = e.WriteFloat32(float32(rv.Float()), LE)
+		break
+	case reflect.Float64:
+		err = e.WriteFloat64(rv.Float(), LE)
+		break
+	case reflect.Bool:
+		err = e.WriteBool(rv.Bool())
+		break
+	default:
+		isPrimitive = false
+	}
+	return
+}
+
 func (e *Encoder) encodeBorsh(rv reflect.Value, opt *option) (err error) {
 	if opt == nil {
 		opt = newDefaultOption()
@@ -70,35 +119,15 @@ func (e *Encoder) encodeBorsh(rv reflect.Value, opt *option) (err error) {
 		return marshaler.MarshalWithEncoder(e)
 	}
 
+	// Encode the value if it's a primitive type
+	isPrimitive, err := e.encodePrimitive(rv, nil)
+	if isPrimitive {
+		return
+	} else if err != nil {
+		return err
+	}
+
 	switch rv.Kind() {
-	// case reflect.Int:
-	// 	return e.WriteInt64(rv.Int(), LE)
-	// case reflect.Uint:
-	// 	return e.WriteUint64(rv.Uint(), LE)
-	case reflect.String:
-		return e.WriteString(rv.String())
-	case reflect.Uint8:
-		return e.WriteByte(byte(rv.Uint()))
-	case reflect.Int8:
-		return e.WriteByte(byte(rv.Int()))
-	case reflect.Int16:
-		return e.WriteInt16(int16(rv.Int()), LE)
-	case reflect.Uint16:
-		return e.WriteUint16(uint16(rv.Uint()), LE)
-	case reflect.Int32:
-		return e.WriteInt32(int32(rv.Int()), LE)
-	case reflect.Uint32:
-		return e.WriteUint32(uint32(rv.Uint()), LE)
-	case reflect.Uint64:
-		return e.WriteUint64(rv.Uint(), LE)
-	case reflect.Int64:
-		return e.WriteInt64(rv.Int(), LE)
-	case reflect.Float32:
-		return e.WriteFloat32(float32(rv.Float()), LE)
-	case reflect.Float64:
-		return e.WriteFloat64(rv.Float(), LE)
-	case reflect.Bool:
-		return e.WriteBool(rv.Bool())
 	case reflect.Ptr:
 		if rv.IsNil() {
 			el := reflect.New(rv.Type().Elem()).Elem()
@@ -222,18 +251,29 @@ func (enc *Encoder) encodeComplexEnumBorsh(rv reflect.Value) error {
 	if int(enum)+1 >= t.NumField() {
 		return errors.New("complex enum too large")
 	}
+	// Enum is empty
 	field := rv.Field(int(enum) + 1)
-
+	if isTypeBorshEnumEmpty(field.Type()) {
+		return nil
+	}
 	if field.Kind() == reflect.Ptr {
 		field = field.Elem()
 	}
 	if field.Kind() == reflect.Struct {
 		return enc.encodeStructBorsh(field.Type(), field)
 	}
+	// Encode the value if it's a primitive type
+	isPrimitive, err := enc.encodePrimitive(field, nil)
+	if isPrimitive {
+		return nil
+	} else if err != nil {
+		return err
+	}
 	return nil
 }
 
 type BorshEnum uint8
+type BorshEnumEmpty struct {}
 
 func (e *Encoder) encodeStructBorsh(rt reflect.Type, rv reflect.Value) (err error) {
 	l := rv.NumField()

--- a/encoder_borsh.go
+++ b/encoder_borsh.go
@@ -270,6 +270,7 @@ func (enc *Encoder) encodeComplexEnumBorsh(rv reflect.Value) error {
 }
 
 type BorshEnum uint8
+
 // EmptyVariant is an empty borsh enum variant.
 type EmptyVariant struct{}
 

--- a/encoder_borsh.go
+++ b/encoder_borsh.go
@@ -253,9 +253,6 @@ func (enc *Encoder) encodeComplexEnumBorsh(rv reflect.Value) error {
 	}
 	// Enum is empty
 	field := rv.Field(int(enum) + 1)
-	if isTypeBorshEnumEmpty(field.Type()) {
-		return nil
-	}
 	if field.Kind() == reflect.Ptr {
 		field = field.Elem()
 	}
@@ -273,7 +270,16 @@ func (enc *Encoder) encodeComplexEnumBorsh(rv reflect.Value) error {
 }
 
 type BorshEnum uint8
+// EmptyVariant is an empty borsh enum variant.
 type EmptyVariant struct{}
+
+func (_ *EmptyVariant) MarshalWithEncoder(_ *Encoder) error {
+	return nil
+}
+
+func (_ *EmptyVariant) UnmarshalWithEncoder(_ *Encoder) error {
+	return nil
+}
 
 func (e *Encoder) encodeStructBorsh(rt reflect.Type, rv reflect.Value) (err error) {
 	l := rv.NumField()

--- a/encoder_borsh.go
+++ b/encoder_borsh.go
@@ -35,40 +35,28 @@ func (e *Encoder) encodePrimitive(rv reflect.Value, opt *option) (isPrimitive bo
 	// 	err = e.WriteUint64(rv.Uint(), LE)
 	case reflect.String:
 		err = e.WriteString(rv.String())
-		break
 	case reflect.Uint8:
 		err = e.WriteByte(byte(rv.Uint()))
-		break
 	case reflect.Int8:
 		err = e.WriteByte(byte(rv.Int()))
-		break
 	case reflect.Int16:
 		err = e.WriteInt16(int16(rv.Int()), LE)
-		break
 	case reflect.Uint16:
 		err = e.WriteUint16(uint16(rv.Uint()), LE)
-		break
 	case reflect.Int32:
 		err = e.WriteInt32(int32(rv.Int()), LE)
-		break
 	case reflect.Uint32:
 		err = e.WriteUint32(uint32(rv.Uint()), LE)
-		break
 	case reflect.Uint64:
 		err = e.WriteUint64(rv.Uint(), LE)
-		break
 	case reflect.Int64:
 		err = e.WriteInt64(rv.Int(), LE)
-		break
 	case reflect.Float32:
 		err = e.WriteFloat32(float32(rv.Float()), LE)
-		break
 	case reflect.Float64:
 		err = e.WriteFloat64(rv.Float(), LE)
-		break
 	case reflect.Bool:
 		err = e.WriteBool(rv.Bool())
-		break
 	default:
 		isPrimitive = false
 	}

--- a/encoder_borsh.go
+++ b/encoder_borsh.go
@@ -273,7 +273,7 @@ func (enc *Encoder) encodeComplexEnumBorsh(rv reflect.Value) error {
 }
 
 type BorshEnum uint8
-type BorshEnumEmpty struct{}
+type EmptyVariant struct{}
 
 func (e *Encoder) encodeStructBorsh(rt reflect.Type, rv reflect.Value) (err error) {
 	l := rv.NumField()

--- a/encoder_borsh.go
+++ b/encoder_borsh.go
@@ -37,7 +37,7 @@ func (e *Encoder) encodePrimitive(rv reflect.Value, opt *option) (isPrimitive bo
 		err = e.WriteString(rv.String())
 		break
 	case reflect.Uint8:
-		err =  e.WriteByte(byte(rv.Uint()))
+		err = e.WriteByte(byte(rv.Uint()))
 		break
 	case reflect.Int8:
 		err = e.WriteByte(byte(rv.Int()))
@@ -273,7 +273,7 @@ func (enc *Encoder) encodeComplexEnumBorsh(rv reflect.Value) error {
 }
 
 type BorshEnum uint8
-type BorshEnumEmpty struct {}
+type BorshEnumEmpty struct{}
 
 func (e *Encoder) encodeStructBorsh(rt reflect.Type, rv reflect.Value) (err error) {
 	l := rv.NumField()

--- a/encoder_borsh.go
+++ b/encoder_borsh.go
@@ -122,8 +122,6 @@ func (e *Encoder) encodeBorsh(rv reflect.Value, opt *option) (err error) {
 	// Encode the value if it's a primitive type
 	isPrimitive, err := e.encodePrimitive(rv, nil)
 	if isPrimitive {
-		return
-	} else if err != nil {
 		return err
 	}
 
@@ -262,8 +260,6 @@ func (enc *Encoder) encodeComplexEnumBorsh(rv reflect.Value) error {
 	// Encode the value if it's a primitive type
 	isPrimitive, err := enc.encodePrimitive(field, nil)
 	if isPrimitive {
-		return nil
-	} else if err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This allows an enum represented in Rust:
```rust
enum MyEnum {
    One,
    Two(u32),
    Three(i16),
}
```

to be serialized/deserialized using:
```go
type MyEnum struct {
	Enum BorshEnum `borsh_enum:"true"`
	One EmptyVariant
	Two uint32
	Three int16
}
```