### PR TITLE
Fix typo in EmptyEnum UnmarshalWithDecoder

### DIFF
--- a/encoder_borsh.go
+++ b/encoder_borsh.go
@@ -262,7 +262,7 @@ func (_ *EmptyVariant) MarshalWithEncoder(_ *Encoder) error {
 	return nil
 }
 
-func (_ *EmptyVariant) UnmarshalWithEncoder(_ *Encoder) error {
+func (_ *EmptyVariant) UnmarshalWithDecoder(_ *Decoder) error {
 	return nil
 }
 


### PR DESCRIPTION
The code still passed the tests since the decoder skipped the unknown type