### PR TITLE
decoder: add slice len bounds checks

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -245,11 +245,17 @@ func (dec *Decoder) ReadLength() (length int, err error) {
 		if err != nil {
 			return 0, err
 		}
+		if val > 0x7FFF_FFFF {
+			return 0, io.ErrUnexpectedEOF
+		}
 		length = int(val)
 	case EncodingBorsh:
 		val, err := dec.ReadUint32(LE)
 		if err != nil {
 			return 0, err
+		}
+		if val > 0x7FFF_FFFF {
+			return 0, io.ErrUnexpectedEOF
 		}
 		length = int(val)
 	case EncodingCompactU16:

--- a/decoder_borsh.go
+++ b/decoder_borsh.go
@@ -20,6 +20,7 @@ package bin
 import (
 	"errors"
 	"fmt"
+	"io"
 	"reflect"
 
 	"go.uber.org/zap"
@@ -199,6 +200,9 @@ func (dec *Decoder) decodeBorsh(rv reflect.Value, opt *option) (err error) {
 		if l == 0 {
 			// Empty slices are left nil
 			return
+		}
+		if l > dec.Remaining() {
+			return io.ErrUnexpectedEOF
 		}
 
 		rv.Set(reflect.MakeSlice(rt, l, l))

--- a/decoder_compact-u16.go
+++ b/decoder_compact-u16.go
@@ -19,6 +19,7 @@ package bin
 
 import (
 	"fmt"
+	"io"
 	"reflect"
 
 	"go.uber.org/zap"
@@ -177,6 +178,10 @@ func (dec *Decoder) decodeCompactU16(rv reflect.Value, opt *option) (err error) 
 
 		if traceEnabled {
 			zlog.Debug("reading slice", zap.Int("len", l), typeField("type", rv))
+		}
+
+		if l > dec.Remaining() {
+			return io.ErrUnexpectedEOF
 		}
 
 		rv.Set(reflect.MakeSlice(rt, l, l))

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -599,7 +599,16 @@ func TestDecoder_Slice_Err(t *testing.T) {
 
 	decoder = NewBinDecoder(buf)
 	err = decoder.Decode(&s)
-	assert.EqualError(t, err, "decode: uint64 required [8] bytes, remaining [0]")
+	assert.EqualError(t, err, "unexpected EOF")
+}
+
+func TestDecoder_Slice_InvalidLen(t *testing.T) {
+	buf := []byte{0xd7, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01}
+
+	decoder := NewBinDecoder(buf)
+	var s []string
+	err := decoder.Decode(&s)
+	assert.EqualError(t, err, "unexpected EOF")
 }
 
 func TestDecoder_Int64(t *testing.T) {

--- a/variant.go
+++ b/variant.go
@@ -147,10 +147,10 @@ var NoTypeIDDefaultID = TypeIDFromUint8(0)
 
 // NewVariantDefinition creates a variant definition based on the *ordered* provided types.
 //
-// - For anchor instructions, it's the name that defines the binary variant value.
-// - For all other types, it's the ordering that defines the binary variant value just like in native `nodeos` C++
-//   and in Smart Contract via the `std::variant` type. It's important to pass the entries
-//   in the right order!
+//   - For anchor instructions, it's the name that defines the binary variant value.
+//   - For all other types, it's the ordering that defines the binary variant value just like in native `nodeos` C++
+//     and in Smart Contract via the `std::variant` type. It's important to pass the entries
+//     in the right order!
 //
 // This variant definition can now be passed to functions of `BaseVariant` to implement
 // marshal/unmarshaling functionalities for binary & JSON.


### PR DESCRIPTION
The decoder performs memory allocations based on untrusted length inputs while decoding slices.

This patch adds an upper constraint to the slice element count before calling `runtime.MakeSlice` in decoder.

It also fixes an integer overflow bug that could result in negative slice lengths.

Rationale: We assume each slice element is at least 1 byte large <sup>1</sup> Thus, for a valid encoding, the number of bytes remaining must be greater or equal to the number of slice elements. If there are less bytes remaining than the slice element count indicates, we would eventually try to read past the buffer and trip on `io.ErrUnexpectedEOF`. Thus we can safely bail early without actually deserializing slice elements.

<sup>1</sup> A slice element can reasonably only be zero bytes if all other elements are also zero bytes (ignoring custom `UnmarshalWithDecoder`). Zero size slices are rare and should be represented as a single varint instead anyways.

Fixes https://github.com/gagliardetto/solana-go/issues/95