### PR TITLE
fix: Parsing an optional *struct would fail since option wasn't handled

### DIFF
--- a/decoder_borsh.go
+++ b/decoder_borsh.go
@@ -412,6 +412,40 @@ func (dec *Decoder) decodeStructBorsh(rt reflect.Type, rv reflect.Value) (err er
 		ptrImplements := reflect.PtrTo(rt).Implements(unmarshalableType)
 		vImplements := rt.Implements(unmarshalableType)
 		if ptrImplements || vImplements {
+			if option.is_Optional() {
+				isPresent, e := dec.ReadOption()
+				if e != nil {
+					err = fmt.Errorf("decode: %t isPresent, %s", v.Type(), e)
+					return
+				}
+
+				if !isPresent {
+					if traceEnabled {
+						zlog.Debug("decode: skipping optional value", zap.Stringer("type", v.Kind()))
+					}
+
+					v.Set(reflect.Zero(v.Type()))
+					return
+				}
+
+			}
+			if option.is_COptional() {
+				isPresent, e := dec.ReadCOption()
+				if e != nil {
+					err = fmt.Errorf("decode: %t isPresent, %s", v.Type(), e)
+					return
+				}
+
+				if !isPresent {
+					if traceEnabled {
+						zlog.Debug("decode: skipping optional value", zap.Stringer("type", v.Kind()))
+					}
+
+					v.Set(reflect.Zero(v.Type()))
+					return
+				}
+			}
+
 			switch {
 			case ptrImplements:
 				m := reflect.New(rt)


### PR DESCRIPTION
Something like this would fail to parse since the code has a special path for parsing pointers, it ignored the optional annotation.
```
struct Foo {
  bar: *Bar `bin:"optional"`
}

struct Bar {
  baz uint64
}
```